### PR TITLE
OCP HA related fixes and ovs-multitenant

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ You will also need to get the Pool ID that contains your entitlements for OpenSh
 ## Deploy Template
 
 Deploy to Azure using Azure Portal: 
-<a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fharoldwongms%2Fopenshift-containerplatform%2Fmaster%2Fazuredeploy.json" target="_blank"><img src="http://azuredeploy.net/deploybutton.png"/></a>
+<a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fmglantz%2Fopenshift-containerplatform%2Fmaster%2Fazuredeploy.json" target="_blank"><img src="http://azuredeploy.net/deploybutton.png"/></a>
 <a href="http://armviz.io/#/?load=https%3A%2F%2Fraw.githubusercontent.com%2Fharoldwongms%2Fopenshift-containerplatform%2Fmaster%2Fazuredeploy.json" target="_blank">
     <img src="http://armviz.io/visualizebutton.png"/>
 </a><br/>

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This template deploys OpenShift Container Platform with basic username / passwor
 |Infra Load Balancer	|3 probes and 3 rules for TCP 80, TCP 443 and TCP 9090 									                                             |
 |Public IP Addresses	|Bastion Public IP for Bastion Node<br />OpenShift Master public IP attached Master Load Balancer<br />OpenShift Router public IP attached to Infra Load Balancer            |
 |Storage Accounts   	|2 Storage Accounts                                                                                                                  |
-|Virtual Machines   	|1 Bastion Node - Used to Run Ansible Playbook for OpenShift deployment<br />1 or 3 Masters. Master 1 is used to run a NFS server to provide persistent storage.<br />1 or 3 Infra nodes<br />User-defined number of nodes<br />All VMs include a single attached data disk for Docker thin pool logical volume|
+|Virtual Machines   	|1 Bastion Node - Used both to Run Ansible Playbook for OpenShift deployment and to do internal load balancing to the masters<br />1 or 3 Masters. Master 1 is used to run a NFS server to provide persistent storage.<br />1 or 3 Infra nodes<br />User-defined number of nodes<br />All VMs include a single attached data disk for Docker thin pool logical volume|
 ## READ the instructions in its entirety before deploying!
 
 This template deploys multiple VMs and requires some pre-work before you can successfully deploy the OpenShift Cluster.  If you don't get the pre-work done correctly, you will most likely fail to deploy the cluster using this template.  Please read the instructions completely before you proceed. 
@@ -77,7 +77,7 @@ You will also need to get the Pool ID that contains your entitlements for OpenSh
 ## Deploy Template
 
 Deploy to Azure using Azure Portal: 
-<a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fmglantz%2Fopenshift-containerplatform%2Fmaster%2Fazuredeploy.json" target="_blank"><img src="http://azuredeploy.net/deploybutton.png"/></a>
+<a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fharoldwongms%2Fopenshift-containerplatform%2Fmaster%2Fazuredeploy.json" target="_blank"><img src="http://azuredeploy.net/deploybutton.png"/></a>
 <a href="http://armviz.io/#/?load=https%3A%2F%2Fraw.githubusercontent.com%2Fharoldwongms%2Fopenshift-containerplatform%2Fmaster%2Fazuredeploy.json" target="_blank">
     <img src="http://armviz.io/visualizebutton.png"/>
 </a><br/>

--- a/azuredeploy.json
+++ b/azuredeploy.json
@@ -8,7 +8,7 @@
 				"description": "Base URL for Template Files",
 				"artifactsBaseUrl": ""
 			},
-			"defaultValue": "https://raw.githubusercontent.com/haroldwongms/openshift-containerplatform/master/"
+			"defaultValue": "https://raw.githubusercontent.com/mglantz/openshift-containerplatform/master/"
 		},
 		"masterVmSize": {
 			"type": "string",

--- a/azuredeploy.json
+++ b/azuredeploy.json
@@ -739,7 +739,7 @@
 							"id": "[variables('masterLbBackendPoolId')]"
 						},
 						"protocol": "Tcp",
-						"sessionPersistence": "sourceIP",
+						"loadDistribution": "sourceIP",
 						"idleTimeoutInMinutes": 30,
 						"frontendPort": 8443,
 						"backendPort": 8443,

--- a/azuredeploy.json
+++ b/azuredeploy.json
@@ -740,6 +740,7 @@
 						},
 						"protocol": "Tcp",
 						"loadDistribution": "SourceIP",
+						"idleTimeoutInMinutes": 30,
 						"frontendPort": 8443,
 						"backendPort": 8443,
 						"probe": {
@@ -757,6 +758,7 @@
 						},
 						"protocol": "Tcp",
 						"loadDistribution": "SourceIP",
+						"idleTimeoutInMinutes": 30,
 						"frontendPort": 9090,
 						"backendPort": 9090,
 						"probe": {

--- a/azuredeploy.json
+++ b/azuredeploy.json
@@ -739,7 +739,7 @@
 							"id": "[variables('masterLbBackendPoolId')]"
 						},
 						"protocol": "Tcp",
-						"LoadBalancerDistribution": "sourceIP",
+						"sessionPersistence": "sourceIP",
 						"idleTimeoutInMinutes": 30,
 						"frontendPort": 8443,
 						"backendPort": 8443,

--- a/azuredeploy.json
+++ b/azuredeploy.json
@@ -739,6 +739,7 @@
 							"id": "[variables('masterLbBackendPoolId')]"
 						},
 						"protocol": "Tcp",
+						"sessionPersistence": "clientIP",
 						"idleTimeoutInMinutes": 30,
 						"frontendPort": 8443,
 						"backendPort": 8443,

--- a/azuredeploy.json
+++ b/azuredeploy.json
@@ -8,7 +8,7 @@
 				"description": "Base URL for Template Files",
 				"artifactsBaseUrl": ""
 			},
-			"defaultValue": "https://raw.githubusercontent.com/mglantz/openshift-containerplatform/master/"
+			"defaultValue": "https://raw.githubusercontent.com/haroldwongms/openshift-containerplatform/master/"
 		},
 		"masterVmSize": {
 			"type": "string",

--- a/azuredeploy.json
+++ b/azuredeploy.json
@@ -739,7 +739,7 @@
 							"id": "[variables('masterLbBackendPoolId')]"
 						},
 						"protocol": "Tcp",
-						"sessionPersistence": "clientIP",
+						"sessionPersistence": "Client IP",
 						"idleTimeoutInMinutes": 30,
 						"frontendPort": 8443,
 						"backendPort": 8443,

--- a/azuredeploy.json
+++ b/azuredeploy.json
@@ -757,6 +757,8 @@
 							"id": "[variables('masterLbBackendPoolId')]"
 						},
 						"protocol": "Tcp",
+						"loadDistribution": "sourceIP",
+						"idleTimeoutInMinutes": 30,
 						"frontendPort": 9090,
 						"backendPort": 9090,
 						"probe": {

--- a/azuredeploy.json
+++ b/azuredeploy.json
@@ -739,7 +739,7 @@
 							"id": "[variables('masterLbBackendPoolId')]"
 						},
 						"protocol": "Tcp",
-						"sessionPersistence": "Client IP",
+						"LoadBalancerDistribution": "sourceIP",
 						"idleTimeoutInMinutes": 30,
 						"frontendPort": 8443,
 						"backendPort": 8443,

--- a/azuredeploy.json
+++ b/azuredeploy.json
@@ -739,6 +739,7 @@
 							"id": "[variables('masterLbBackendPoolId')]"
 						},
 						"protocol": "Tcp",
+						"idleTimeoutInMinutes": 30,
 						"frontendPort": 8443,
 						"backendPort": 8443,
 						"probe": {

--- a/azuredeploy.json
+++ b/azuredeploy.json
@@ -86,7 +86,7 @@
 			"type": "int",
 			"defaultValue": 1,
 			"minValue": 1,
-			"allowedValues": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+			"allowedValues": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30],
 			"metadata": {
 				"description": "Number of OpenShift nodes"
 			}

--- a/azuredeploy.parameters.json
+++ b/azuredeploy.parameters.json
@@ -3,7 +3,7 @@
 	"contentVersion": "1.0.0.0",
 	"parameters": {
 		"_artifactsLocation": {
-			"value": "https://raw.githubusercontent.com/haroldwongms/openshift-containerplatform/master/"
+			"value": "https://raw.githubusercontent.com/mglantz/openshift-containerplatform/master/"
 		},
 		"masterVmSize": {
 			"value": "Standard_DS2_v2"

--- a/azuredeploy.parameters.json
+++ b/azuredeploy.parameters.json
@@ -3,7 +3,7 @@
 	"contentVersion": "1.0.0.0",
 	"parameters": {
 		"_artifactsLocation": {
-			"value": "https://raw.githubusercontent.com/mglantz/openshift-containerplatform/master/"
+			"value": "https://raw.githubusercontent.com/haroldwongms/openshift-containerplatform/master/"
 		},
 		"masterVmSize": {
 			"value": "Standard_DS2_v2"

--- a/scripts/deployOpenShift.sh
+++ b/scripts/deployOpenShift.sh
@@ -108,6 +108,7 @@ openshift_use_dnsmasq=false
 openshift_master_default_subdomain=$ROUTING
 openshift_override_hostname_check=true
 osm_use_cockpit=true
+os_sdn_network_plugin_name='redhat/openshift-ovs-multitenant'
 
 openshift_master_cluster_hostname=$MASTERPUBLICIPHOSTNAME
 openshift_master_cluster_public_hostname=$MASTERPUBLICIPHOSTNAME

--- a/scripts/deployOpenShift.sh
+++ b/scripts/deployOpenShift.sh
@@ -109,9 +109,10 @@ openshift_master_default_subdomain=$ROUTING
 openshift_override_hostname_check=true
 osm_use_cockpit=true
 
+openshift_master_cluster_method=native
 openshift_master_cluster_hostname=$MASTERPUBLICIPHOSTNAME
 openshift_master_cluster_public_hostname=$MASTERPUBLICIPHOSTNAME
-openshift_master_cluster_public_vip=$MASTERPUBLICIPADDRESS
+#openshift_master_cluster_public_vip=$MASTERPUBLICIPADDRESS
 
 # Enable HTPasswdPasswordIdentityProvider
 openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 'challenge': 'true', 'kind': 'HTPasswdPasswordIdentityProvider', 'filename': '/etc/origin/master/htpasswd'}]

--- a/scripts/deployOpenShift.sh
+++ b/scripts/deployOpenShift.sh
@@ -181,6 +181,7 @@ openshift_use_dnsmasq=false
 openshift_master_default_subdomain=$ROUTING
 openshift_override_hostname_check=true
 osm_use_cockpit=true
+os_sdn_network_plugin_name='redhat/openshift-ovs-multitenant'
 
 openshift_master_cluster_method=native
 openshift_master_cluster_hostname=$MASTERPUBLICIPHOSTNAME

--- a/scripts/deployOpenShift.sh
+++ b/scripts/deployOpenShift.sh
@@ -73,7 +73,7 @@ EOF
 # Run on all nodes
 cat > /home/${SUDOUSER}/postinstall3.yml <<EOF
 ---
-- hosts: nfs
+- hosts: nodes
   remote_user: ${SUDOUSER}
   become: yes
   become_method: sudo

--- a/scripts/deployOpenShift.sh
+++ b/scripts/deployOpenShift.sh
@@ -109,7 +109,6 @@ openshift_master_default_subdomain=$ROUTING
 openshift_override_hostname_check=true
 osm_use_cockpit=true
 
-openshift_master_cluster_method=native
 openshift_master_cluster_hostname=$MASTERPUBLICIPHOSTNAME
 openshift_master_cluster_public_hostname=$MASTERPUBLICIPHOSTNAME
 #openshift_master_cluster_public_vip=$MASTERPUBLICIPADDRESS
@@ -186,7 +185,7 @@ osm_use_cockpit=true
 openshift_master_cluster_method=native
 openshift_master_cluster_hostname=$MASTERPUBLICIPHOSTNAME
 openshift_master_cluster_public_hostname=$MASTERPUBLICIPHOSTNAME
-openshift_master_cluster_public_vip=$MASTERPUBLICIPADDRESS
+#openshift_master_cluster_public_vip=$MASTERPUBLICIPADDRESS
 
 # Enable HTPasswdPasswordIdentityProvider
 openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 'challenge': 'true', 'kind': 'HTPasswdPasswordIdentityProvider', 'filename': '/etc/origin/master/htpasswd'}]

--- a/scripts/deployOpenShift.sh
+++ b/scripts/deployOpenShift.sh
@@ -15,6 +15,7 @@ NODE=$8
 NODECOUNT=$9
 MASTERCOUNT=${10}
 ROUTING=${11}
+BASTION=$(hostname -f)
 
 MASTERLOOP=$((MASTERCOUNT - 1))
 NODELOOP=$((NODECOUNT - 1))
@@ -170,6 +171,7 @@ masters
 nodes
 etcd
 nfs
+lb
 
 # Set variables common for all OSEv3 hosts
 [OSEv3:vars]
@@ -185,7 +187,7 @@ osm_use_cockpit=true
 os_sdn_network_plugin_name='redhat/openshift-ovs-multitenant'
 
 openshift_master_cluster_method=native
-openshift_master_cluster_hostname=$MASTERPUBLICIPHOSTNAME
+openshift_master_cluster_hostname=$BASTION
 openshift_master_cluster_public_hostname=$MASTERPUBLICIPHOSTNAME
 #openshift_master_cluster_public_vip=$MASTERPUBLICIPADDRESS
 
@@ -232,6 +234,9 @@ $MASTER-[0:${MASTERLOOP}].$DOMAIN
 
 [nfs]
 $MASTER-0.$DOMAIN
+
+[lb]
+$BASTION
 
 # host group for nodes
 [nodes]


### PR DESCRIPTION
* Removal of VIP address (this is just if we are using non-native (active-passive) cluster mode, which is something to avoid)
* Master LB now uses Client IP session persistence with a timeout of 30 minutes, this resolves SSL certificate and console issues when each request get’s send to a different master.
* Bastion host used to load balance cluster internal API traffic to masters. This sets up HA-Proxy on the bastion host, which then load balances the traffic. This resolves the issue where the external master LB does not have knowledge about the internal OpenShift SDN.
* OpenShift SDN now uses the ovs-multitenant network plugin, meaning that each project created in OpenShift is segmented off from the rest of the non-global projects in the cluster, not having this configured is a normal showstopper for implementation due to traditional network/security requirements in place. It’s possible to move back to the default plugin, ovs-subnet (all projects can talk to all projects) by reconfiguring the master/node-config.yaml files to point at the ova-subnet plugin and restarting masters/nodes, moving the other way is problematic as you then have to had kept tab on all communication between all projects.
* Changed max application nodes from 10 to 30, should cater for most use cases, 10 nodes to run containers on may be a bit to small.
