### PR TITLE
Changed from using rhsm username and password to organization id and activation key.

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,9 +66,9 @@ You will also need to get the Pool ID that contains your entitlements for OpenSh
 9.  dataDiskSize: Size of data disk to attach to nodes for Docker volume - valid sizes are 128 GB, 512 GB and 1023 GB
 10. adminUsername: Admin username for both OS (VM) login and initial OpenShift user
 11. openshiftPassword: Password for OpenShift user
-12. cloudAccessUsername: Your Red Hat Cloud Access subscription user name
-13. cloudAccessPassword: The password for your Red Hat Cloud Access subscription
-14. cloudAccessPoolId: The Pool ID that contains your OpenShift entitlements
+12. rhsmOrgId: The Red Hat Subscription Manager Organization ID for your Cloud Access subscription. You can get this by running ```subscription-manager identity``` on a registered machine.
+13. rhsmActivationKey: The Red Hat Subscription Manager Activation Key for your Cloud Access subscription. You can get this from [here](https://access.redhat.com/management/activation_keys).
+14. rhsmPoolId: The Red Hat Subscription Manager Pool ID that contains your OpenShift entitlements
 15. sshPublicKey: Copy your SSH Public Key here
 16. keyVaultResourceGroup: The name of the Resource Group that contains the Key Vault
 17. keyVaultName: The name of the Key Vault you created

--- a/azuredeploy.json
+++ b/azuredeploy.json
@@ -115,25 +115,25 @@
 				"description": "Password for OpenShift user to login to OpenShift Console"
 			}
 		},
-		"cloudAccessUsername": {
-			"type": "string",
-			"minLength": 1,
-			"metadata": {
-				"description": "Red Hat Cloud Access Username (login credentials for access.redhat.com)"
-			}
-		},
-		"cloudAccessPassword": {
+		"rhsmOrgId": {
 			"type": "securestring",
 			"minLength": 1,
 			"metadata": {
-				"description": "Cloud Access password (login credentials for access.redhat.com)"
+				"description": "Red Hat Subscription Manager Organization ID. To find it, run on registered server: subscription-manager identity"
 			}
 		},
-		"cloudAccessPoolId": {
+		"rhsmActivationKey": {
+			"type": "securestring",
+			"minLength": 1,
+			"metadata": {
+				"description": "Red Hat Subscription Manager Activation Key. To find it, go to: https://access.redhat.com/management/activation_keys"
+			}
+		},
+		"rhsmPoolId": {
 			"type": "string",
 			"minLength": 1,
 			"metadata": {
-				"description": "Pool ID with OpenShift entitlements (To find it, run on registered server: subscription-manager list)"
+				"description": "Red Hat Subscription Manager Pool ID with OpenShift entitlements. To find it, run on registered server: subscription-manager list"
 			}
 		},
 		"sshPublicKey": {
@@ -1413,7 +1413,7 @@
 					]
 				},
 				"protectedSettings": {
-					"commandToExecute": "[concat('bash ', variables('bastionPrepScriptFileName'), ' ', parameters('cloudAccessUsername'), ' ', variables('singlequote'), parameters('cloudAccessPassword'), variables('singlequote'), ' ', parameters('cloudAccessPoolId'))]"
+					"commandToExecute": "[concat('bash ', variables('bastionPrepScriptFileName'), ' ', parameters('rhsmOrgId'), ' ', variables('singlequote'), parameters('rhsmActivationKey'), variables('singlequote'), ' ', parameters('rhsmPoolId'))]"
 				}
 			}
 		}, {
@@ -1438,7 +1438,7 @@
 					]
 				},
 				"protectedSettings": {
-					"commandToExecute": "[concat('bash ', variables('loadBalancerPrepScriptFileName'), ' ', parameters('cloudAccessUsername'), ' ', variables('singlequote'), parameters('cloudAccessPassword'), variables('singlequote'), ' ', parameters('cloudAccessPoolId'))]"
+					"commandToExecute": "[concat('bash ', variables('loadBalancerPrepScriptFileName'), ' ', parameters('rhsmOrgId'), ' ', variables('singlequote'), parameters('rhsmActivationKey'), variables('singlequote'), ' ', parameters('rhsmPoolId'))]"
 				}
 			}
 		}, {
@@ -1467,7 +1467,7 @@
 					]
 				},
 				"protectedSettings": {
-					"commandToExecute": "[concat('bash ', variables('masterPrepScriptFileName'), ' ', parameters('cloudAccessUsername'), ' ', variables('singlequote'), parameters('cloudAccessPassword'), variables('singlequote'), ' ', parameters('cloudAccessPoolId'))]"
+					"commandToExecute": "[concat('bash ', variables('masterPrepScriptFileName'), ' ', parameters('rhsmOrgId'), ' ', variables('singlequote'), parameters('rhsmActivationKey'), variables('singlequote'), ' ', parameters('rhsmPoolId'))]"
 				}
 			}
 		}, {
@@ -1496,7 +1496,7 @@
 					]
 				},
 				"protectedSettings": {
-					"commandToExecute": "[concat('bash ', variables('nodePrepScriptFileName'), ' ', parameters('cloudAccessUsername'), ' ', variables('singlequote'), parameters('cloudAccessPassword'), variables('singlequote'), ' ', parameters('cloudAccessPoolId'))]"
+					"commandToExecute": "[concat('bash ', variables('nodePrepScriptFileName'), ' ', parameters('rhsmOrgId'), ' ', variables('singlequote'), parameters('rhsmActivationKey'), variables('singlequote'), ' ', parameters('rhsmPoolId'))]"
 				}
 			}
 		}, {
@@ -1525,7 +1525,7 @@
 					]
 				},
 				"protectedSettings": {
-					"commandToExecute": "[concat('bash ', variables('nodePrepScriptFileName'), ' ', parameters('cloudAccessUsername'), ' ', variables('singlequote'), parameters('cloudAccessPassword'), variables('singlequote'), ' ', parameters('cloudAccessPoolId'))]"
+					"commandToExecute": "[concat('bash ', variables('nodePrepScriptFileName'), ' ', parameters('rhsmOrgId'), ' ', variables('singlequote'), parameters('rhsmActivationKey'), variables('singlequote'), ' ', parameters('rhsmPoolId'))]"
 				}
 			}
 		}, {

--- a/azuredeploy.parameters.json
+++ b/azuredeploy.parameters.json
@@ -35,13 +35,13 @@
 		"openshiftPassword": {
 			"value": "changeme"
 		},
-		"cloudAccessUsername": {
+		"rhsmOrgId": {
 			"value": "changeme"
 		},
-		"cloudAccessPassword": {
+		"rhsmActivationKey": {
 			"value": "changeme"
 		},
-		"cloudAccessPoolId": {
+		"rhsmPoolId": {
 			"value": "changeme"
 		},
 		"sshPublicKey": {

--- a/scripts/bastionPrep.sh
+++ b/scripts/bastionPrep.sh
@@ -1,19 +1,19 @@
 #!/bin/bash
 echo $(date) " - Starting Script"
 
-USER=$1
-PASSWORD="$2"
+ORG=$1
+ACT_KEY="$2"
 POOL_ID=$3
 
 # Register Host with Cloud Access Subscription
 echo $(date) " - Register host with Cloud Access Subscription"
 
-subscription-manager register --username="$USER" --password="$PASSWORD"
+subscription-manager register --org="$ORG" --activationkey="$ACT_KEY"
 if [ $? -eq 0 ]
 then
    echo "Subscribed successfully"
 else
-   echo "Incorrect Username and / or Password specified"
+   echo "Incorrect Organization ID and / or Activation Key specified"
    exit 3
 fi
 

--- a/scripts/loadBalancerPrep.sh
+++ b/scripts/loadBalancerPrep.sh
@@ -1,19 +1,19 @@
 #!/bin/bash
 echo $(date) " - Starting Script"
 
-USER=$1
-PASSWORD="$2"
+ORG=$1
+ACT_KEY="$2"
 POOL_ID=$3
 
 # Register Host with Cloud Access Subscription
 echo $(date) " - Register host with Cloud Access Subscription"
 
-subscription-manager register --username="$USER" --password="$PASSWORD"
+subscription-manager register --org="$ORG" --activationkey="$ACT_KEY"
 if [ $? -eq 0 ]
 then
    echo "Subscribed successfully"
 else
-   echo "Incorrect Username and / or Password specified"
+   echo "Incorrect Organization ID and / or Activation Key specified"
    exit 3
 fi
 

--- a/scripts/masterPrep.sh
+++ b/scripts/masterPrep.sh
@@ -1,19 +1,19 @@
 #!/bin/bash
 echo $(date) " - Starting Script"
 
-USER=$1
-PASSWORD="$2"
+ORG=$1
+ACT_KEY="$2"
 POOL_ID=$3
 
 # Register Host with Cloud Access Subscription
 echo $(date) " - Register host with Cloud Access Subscription"
 
-subscription-manager register --username="$USER" --password="$PASSWORD"
+subscription-manager register --org="$ORG" --activationkey="$ACT_KEY"
 if [ $? -eq 0 ]
 then
    echo "Subscribed successfully"
 else
-   echo "Incorrect Username and / or Password specified"
+   echo "Incorrect Organization ID and / or Activation Key specified"
    exit 3
 fi
 

--- a/scripts/nodePrep.sh
+++ b/scripts/nodePrep.sh
@@ -1,19 +1,19 @@
 #!/bin/bash
 echo $(date) " - Starting Script"
 
-USER=$1
-PASSWORD="$2"
+ORG=$1
+ACT_KEY="$2"
 POOL_ID=$3
 
 # Register Host with Cloud Access Subscription
 echo $(date) " - Register host with Cloud Access Subscription"
 
-subscription-manager register --username="$USER" --password="$PASSWORD"
+subscription-manager register --org="$ORG" --activationkey="$ACT_KEY"
 if [ $? -eq 0 ]
 then
    echo "Subscribed successfully"
 else
-   echo "Incorrect Username and / or Password specified"
+   echo "Incorrect Organization ID and / or Activation Key specified"
    exit 3
 fi
 


### PR DESCRIPTION
* Changed from using rhsm username and password to organization id and activation key.

* Also changed the variable names from `cloudAccess*` which is vague to `rhsm*`. Harold, if you hate this, let me know and I can change it back.

* Updated the descriptions for `rhsm*` variables to include a description on how to get the information.

* Tested that these changes work by creating a cluster using the arm template and variables. All hosts were successfully register to my rhsm account.